### PR TITLE
Update crop mode and persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.9.3 - 2025-07-21 19:00 UTC
+- Crop sliders removed; crop mode toggled with a button
+- Image edits save automatically when switching chapters
+
 ## 0.6.9.2 - 2025-07-21 18:38 UTC
 - Fixed images not saving in chapters; edits to pictures now persist
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CalWriter
 
 
-Version 0.6.9.2
+Version 0.6.9.3
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.6.9.2"
+VERSION = "0.6.9.3"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))

--- a/static/editor.js
+++ b/static/editor.js
@@ -173,9 +173,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const imageTools = document.getElementById('image_tools');
     const widthInput = document.getElementById('img_width');
     const heightInput = document.getElementById('img_height');
-    const cropX = document.getElementById('crop_x');
-    const cropY = document.getElementById('crop_y');
+    const cropBtn = document.getElementById('img_crop_toggle');
     let currentImage = null;
+    let cropMode = false;
 
     const handleBox = document.createElement('div');
     handleBox.id = 'img_handles';
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
         drag = {
             dir: e.target.dataset.dir,
-            mode: e.ctrlKey ? 'crop' : 'resize',
+            mode: cropMode ? 'crop' : 'resize',
             startX: e.clientX,
             startY: e.clientY,
             startWidth: currentImage.offsetWidth,
@@ -281,6 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
         document.removeEventListener('mousemove', onDrag);
         document.removeEventListener('mouseup', stopDrag);
         drag = null;
+        if (editor) editor.dispatchEvent(new Event('input'));
     }
 
     handleBox.addEventListener('mousedown', startDrag);
@@ -292,9 +293,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 imageTools.style.display = 'block';
                 widthInput.value = parseInt(img.style.width) || img.width;
                 heightInput.value = parseInt(img.style.height) || img.height;
-                const pos = img.style.objectPosition ? img.style.objectPosition.split(' ') : ['50%', '50%'];
-                cropX.value = parseInt(pos[0]);
-                cropY.value = parseInt(pos[1]);
+                cropMode = false;
+                cropBtn.classList.remove('active');
+                handleBox.querySelectorAll('.img-handle').forEach(h => {
+                    h.classList.remove('crop');
+                    h.classList.add('resize');
+                });
                 updateHandles();
             } else {
                 imageTools.style.display = 'none';
@@ -309,30 +313,36 @@ document.addEventListener('DOMContentLoaded', () => {
             currentImage.style.width = widthInput.value + 'px';
             currentImage.style.height = heightInput.value + 'px';
             updateHandles();
+            editor.dispatchEvent(new Event('input'));
         });
         document.getElementById('img_align_left').addEventListener('click', () => {
             if (!currentImage) return;
             currentImage.style.float = 'left';
             currentImage.style.display = '';
             currentImage.style.margin = '0 10px 10px 0';
+            editor.dispatchEvent(new Event('input'));
         });
         document.getElementById('img_align_center').addEventListener('click', () => {
             if (!currentImage) return;
             currentImage.style.float = 'none';
             currentImage.style.display = 'block';
             currentImage.style.margin = '0 auto 10px';
+            editor.dispatchEvent(new Event('input'));
         });
         document.getElementById('img_align_right').addEventListener('click', () => {
             if (!currentImage) return;
             currentImage.style.float = 'right';
             currentImage.style.display = '';
             currentImage.style.margin = '0 0 10px 10px';
+            editor.dispatchEvent(new Event('input'));
         });
-        document.getElementById('img_apply_crop').addEventListener('click', () => {
-            if (!currentImage) return;
-            currentImage.style.objectFit = 'cover';
-            currentImage.style.objectPosition = cropX.value + '% ' + cropY.value + '%';
-            updateHandles();
+        cropBtn.addEventListener('click', () => {
+            cropMode = !cropMode;
+            cropBtn.classList.toggle('active', cropMode);
+            handleBox.querySelectorAll('.img-handle').forEach(h => {
+                h.classList.toggle('crop', cropMode);
+                h.classList.toggle('resize', !cropMode);
+            });
         });
     }
 

--- a/templates/chapter.html
+++ b/templates/chapter.html
@@ -59,9 +59,7 @@
         <button type="button" id="img_align_center">Center</button>
         <button type="button" id="img_align_right">Right</button>
       </div>
-      <label>Crop X <input type="range" id="crop_x" min="0" max="100" value="50" /></label>
-      <label>Crop Y <input type="range" id="crop_y" min="0" max="100" value="50" /></label>
-      <button type="button" id="img_apply_crop">Apply Crop</button>
+      <button type="button" id="img_crop_toggle">Crop Image</button>
     </div>
     {% if notes_text %}
     <p><a href="{{ url_for('download_note', folder=folder, chapter=chapter) }}">Download Notes</a></p>


### PR DESCRIPTION
## Summary
- keep edited images after switching chapters
- remove crop sliders and add a crop button
- bump version to 0.6.9.3
- update changelog

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687e9a938e2483218cc3ea089f9ac9de