### PR TITLE
Improve image crop mode persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.9.3 - 2025-07-21 19:55 UTC
+- Image crops remain when switching chapters
+- Crop sliders replaced with a crop mode button
+
 ## 0.6.9.2 - 2025-07-21 18:38 UTC
 - Fixed images not saving in chapters; edits to pictures now persist
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CalWriter
 
 
-Version 0.6.9.2
+Version 0.6.9.3
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/app.py
+++ b/app.py
@@ -15,13 +15,14 @@ import re
 from bs4 import BeautifulSoup
 from docx import Document
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 from docx.shared import Inches
 
 app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.6.9.2"
+VERSION = "0.6.9.3"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))
@@ -129,7 +130,18 @@ def sanitize_html(html: str) -> str:
         "*": ["class", "style"],
         "img": ["src", "alt", "width", "height", "style"]
     }
-    return bleach.clean(html, tags=allowed_tags, attributes=allowed_attrs, strip=True)
+    allowed_css = [
+        "width", "height", "float", "display", "margin",
+        "clip-path", "object-fit", "object-position"
+    ]
+    css = CSSSanitizer(allowed_css_properties=allowed_css)
+    return bleach.clean(
+        html,
+        tags=allowed_tags,
+        attributes=allowed_attrs,
+        strip=True,
+        css_sanitizer=css
+    )
 
 
 def html_to_docx(html: str, path: str) -> None:

--- a/static/editor.js
+++ b/static/editor.js
@@ -173,8 +173,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const imageTools = document.getElementById('image_tools');
     const widthInput = document.getElementById('img_width');
     const heightInput = document.getElementById('img_height');
-    const cropX = document.getElementById('crop_x');
-    const cropY = document.getElementById('crop_y');
+    const cropBtn = document.getElementById('img_crop_mode');
+    let cropMode = false;
     let currentImage = null;
 
     const handleBox = document.createElement('div');
@@ -188,6 +188,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     document.body.appendChild(handleBox);
 
+    function updateHandleMode() {
+        handleBox.querySelectorAll('.img-handle').forEach(h => {
+            h.classList.toggle('crop', cropMode);
+            h.classList.toggle('resize', !cropMode);
+        });
+    }
+
     function parseClip(cp) {
         if (!cp || !cp.startsWith('inset(')) return {top:0,right:0,bottom:0,left:0};
         const vals = cp.slice(6,-1).replace(/px/g,'').split(/\s+/).map(parseFloat);
@@ -196,6 +203,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateHandles() {
         if (!currentImage) return;
+        updateHandleMode();
         const rect = currentImage.getBoundingClientRect();
         const clip = parseClip(currentImage.style.clipPath);
         const left = rect.left + window.scrollX + clip.left;
@@ -229,7 +237,7 @@ document.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
         drag = {
             dir: e.target.dataset.dir,
-            mode: e.ctrlKey ? 'crop' : 'resize',
+            mode: cropMode ? 'crop' : 'resize',
             startX: e.clientX,
             startY: e.clientY,
             startWidth: currentImage.offsetWidth,
@@ -292,9 +300,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 imageTools.style.display = 'block';
                 widthInput.value = parseInt(img.style.width) || img.width;
                 heightInput.value = parseInt(img.style.height) || img.height;
-                const pos = img.style.objectPosition ? img.style.objectPosition.split(' ') : ['50%', '50%'];
-                cropX.value = parseInt(pos[0]);
-                cropY.value = parseInt(pos[1]);
+                updateHandleMode();
                 updateHandles();
             } else {
                 imageTools.style.display = 'none';
@@ -328,12 +334,13 @@ document.addEventListener('DOMContentLoaded', () => {
             currentImage.style.display = '';
             currentImage.style.margin = '0 0 10px 10px';
         });
-        document.getElementById('img_apply_crop').addEventListener('click', () => {
-            if (!currentImage) return;
-            currentImage.style.objectFit = 'cover';
-            currentImage.style.objectPosition = cropX.value + '% ' + cropY.value + '%';
-            updateHandles();
-        });
+        if (cropBtn) {
+            cropBtn.addEventListener('click', () => {
+                cropMode = !cropMode;
+                cropBtn.classList.toggle('active', cropMode);
+                updateHandleMode();
+            });
+        }
     }
 
     const sidebar = document.getElementById('notes_sidebar');

--- a/static/style.css
+++ b/static/style.css
@@ -293,6 +293,9 @@ pre.changelog {
 #image_tools .img-align button {
     margin-right: 4px;
 }
+#img_crop_mode.active {
+    background: #fdd;
+}
 
 /* image handles */
 #img_handles{position:absolute;display:none;pointer-events:none;}

--- a/templates/chapter.html
+++ b/templates/chapter.html
@@ -59,9 +59,7 @@
         <button type="button" id="img_align_center">Center</button>
         <button type="button" id="img_align_right">Right</button>
       </div>
-      <label>Crop X <input type="range" id="crop_x" min="0" max="100" value="50" /></label>
-      <label>Crop Y <input type="range" id="crop_y" min="0" max="100" value="50" /></label>
-      <button type="button" id="img_apply_crop">Apply Crop</button>
+      <button type="button" id="img_crop_mode">Crop</button>
     </div>
     {% if notes_text %}
     <p><a href="{{ url_for('download_note', folder=folder, chapter=chapter) }}">Download Notes</a></p>


### PR DESCRIPTION
## Summary
- let crops survive when switching chapters by allowing CSS styles in sanitization
- switch to a crop mode button and remove sidebar sliders
- highlight crop mode button and show handles in red
- bump app version

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e9a938e2483218cc3ea089f9ac9de