### PR TITLE
Add Home link, isolate scroll areas, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.5.5 - 2025-07-22 16:00 UTC
+- Home link added to the sidebar next to Settings
+- Independent scrolling for sidebar, main area, and notes sidebar
+- Version bump to 0.7.5.5
+
 ## 0.7.5.4 - 2025-07-22 15:45 UTC
 - Toolbar buttons replaced with icons
 - Deletion confirmation shows file path on a new line

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.7.5.4
+Version 0.7.5.5
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.7.5.4"
+VERSION = "0.7.5.5"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))

--- a/static/style.css
+++ b/static/style.css
@@ -12,6 +12,7 @@ body {
     line-height: 1.5;
     display: flex;
     height: 100vh;
+    overflow: hidden;
     margin: 0;
     background: var(--bg-color);
     color: var(--text-color);
@@ -56,6 +57,14 @@ body.dark {
     color: var(--text-color);
     text-decoration: none;
     padding: 2px 0;
+}
+#sidebar .sidebar-links a {
+    display: inline;
+    margin-bottom: 0;
+}
+#sidebar .sidebar-links {
+    text-align: center;
+    margin-bottom: 10px;
 }
 #sidebar a:hover {
     text-decoration: underline;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -15,7 +15,10 @@
     <a href="{{ url_for('index') }}"><img src="{{ url_for('asset_file', filename='favicon.ico') }}" class="sidebar-icon" alt="CalWriter icon"></a>
     <a href="{{ url_for('changelog_page') }}" class="version">CalWriter {{ app_version }}</a>
   </div>
-  <a href="{{ url_for('app_settings_page') }}">Settings</a>
+  <div class="sidebar-links">
+    <a href="{{ url_for('index') }}">Home</a> |
+    <a href="{{ url_for('app_settings_page') }}">Settings</a>
+  </div>
   <form action="{{ url_for('search') }}" method="get" id="search_form">
     <input type="text" name="q" placeholder="Search" />
   </form>


### PR DESCRIPTION
## Summary
- add Home link next to Settings and center them
- isolate scrolling for sidebar, main and notes
- bump CalWriter to 0.7.5.5 and update changelog

## Testing
- `pytest -q`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687fb79e5e788321802dd7a29f33fb78