### PR TITLE
Add Home link, isolate scroll areas, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.5.1 - 2025-07-22 16:00 UTC
+- Home link added to the sidebar next to Settings
+- Independent scrolling for sidebar, main area, and notes sidebar
+- Version bump to 0.7.5.1
+
 ## 0.7.5.4 - 2025-07-22 15:45 UTC
 - Toolbar buttons replaced with icons
 - Deletion confirmation shows file path on a new line

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.7.5.4
+Version 0.7.5.1
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.7.5.4"
+VERSION = "0.7.5.1"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))

--- a/static/style.css
+++ b/static/style.css
@@ -12,6 +12,7 @@ body {
     line-height: 1.5;
     display: flex;
     height: 100vh;
+    overflow: hidden;
     margin: 0;
     background: var(--bg-color);
     color: var(--text-color);
@@ -32,11 +33,18 @@ body.dark {
     height: 100vh;
     box-shadow: 2px 0 4px rgba(0,0,0,0.1);
 }
+#sidebar .sidebar-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: fit-content;
+    margin: 0 auto 10px;
+}
 #sidebar .sidebar-title {
     font-weight: bold;
-    margin-bottom: 6px;
     display: flex;
     align-items: center;
+    margin-bottom: 4px;
 }
 #sidebar .sidebar-title .version {
     font-size: 1.1em;
@@ -56,6 +64,13 @@ body.dark {
     color: var(--text-color);
     text-decoration: none;
     padding: 2px 0;
+}
+#sidebar .sidebar-links a {
+    display: inline;
+    margin-bottom: 0;
+}
+#sidebar .sidebar-links {
+    margin-bottom: 4px;
 }
 #sidebar a:hover {
     text-decoration: underline;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -11,11 +11,16 @@
 </head>
 <body class="{% if app_settings.dark_mode %}dark {% endif %}{% block body_class %}{% endblock %}" style="--sidebar-bg: {{ app_settings.sidebar_color if not app_settings.dark_mode else '#333' }}; --text-color: {{ app_settings.text_color if not app_settings.dark_mode else '#eee' }}; --bg-color: {{ app_settings.bg_color if not app_settings.dark_mode else '#222' }}; --toolbar-bg: {{ app_settings.toolbar_color if not app_settings.dark_mode else '#555' }}; --editor-bg: {{ app_settings.editor_color if not app_settings.dark_mode else '#444' }}">
 <div id="sidebar">
-  <div class="sidebar-title">
-    <a href="{{ url_for('index') }}"><img src="{{ url_for('asset_file', filename='favicon.ico') }}" class="sidebar-icon" alt="CalWriter icon"></a>
-    <a href="{{ url_for('changelog_page') }}" class="version">CalWriter {{ app_version }}</a>
+  <div class="sidebar-header">
+    <div class="sidebar-title">
+      <a href="{{ url_for('index') }}"><img src="{{ url_for('asset_file', filename='favicon.ico') }}" class="sidebar-icon" alt="CalWriter icon"></a>
+      <a href="{{ url_for('changelog_page') }}" class="version">CalWriter {{ app_version }}</a>
+    </div>
+    <div class="sidebar-links">
+      <a href="{{ url_for('index') }}">Home</a> |
+      <a href="{{ url_for('app_settings_page') }}">Settings</a>
+    </div>
   </div>
-  <a href="{{ url_for('app_settings_page') }}">Settings</a>
   <form action="{{ url_for('search') }}" method="get" id="search_form">
     <input type="text" name="q" placeholder="Search" />
   </form>


### PR DESCRIPTION
## Summary
- add Home link next to Settings under the app title
- isolate scrolling for sidebar, main and notes
- bump CalWriter to 0.7.5.1 and update changelog
- center Home | Settings links under the title

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687fb79e5e788321802dd7a29f33fb78