### PR TITLE
Add .calwdb export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8 - 2025-07-22 16:43 UTC
+- Added export and import of .calwdb database files
+- Version bump to 0.8
+
 ## 0.7.5.5 - 2025-07-22 16:00 UTC
 - Home link added to the sidebar next to Settings
 - Independent scrolling for sidebar, main area, and notes sidebar

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.7.5.5
+Version 0.8
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,4 +34,11 @@
   <button type="submit">Create Book</button>
   <a href="{{ url_for('book_wizard') }}" class="wizard-link">Book Creation Wizard</a>
 </form>
+<form action="{{ url_for('export_db') }}" method="get" class="export-db-form">
+  <button type="submit">Export Database</button>
+</form>
+<form action="{{ url_for('import_db') }}" method="post" enctype="multipart/form-data" class="import-db-form">
+  <input type="file" name="file" accept=".calwdb" required />
+  <button type="submit">Import Database</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support .calwdb export and import
- add export and import buttons on the home page
- bump version to 0.8
- document the new version and feature

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbf49178883218d10e7551e649da0