### PR TITLE
Add .calwdb export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8 - 2025-07-22 16:43 UTC
+- Added export and import of .calwdb database files
+- Version bump to 0.8
+
 ## 0.7.5.5 - 2025-07-22 16:00 UTC
 - Home link added to the sidebar next to Settings
 - Independent scrolling for sidebar, main area, and notes sidebar

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.7.5.5
+Version 0.8
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/static/style.css
+++ b/static/style.css
@@ -367,4 +367,22 @@ input[type="text"] {
     margin-bottom: 4px;
 }
 
+/* Home page sections */
+.home-links {
+    margin-bottom: 1em;
+}
+
+.home-section {
+    margin-bottom: 2em;
+}
+
+.create-book-form {
+    margin-top: 0.5em;
+}
+
+.db-section form {
+    display: inline-block;
+    margin-right: 0.5em;
+}
+
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,15 +3,16 @@
 {% block content %}
 <h1 class="app-title">CalWriter <span class="version">Version {{ app_version }}</span></h1>
 <p class="description">CalWriter lets you organize books with chapters and notes right in your browser. Files save automatically and can be downloaded whenever you need them.</p>
-<p>
+<nav class="home-links">
   <a href="{{ url_for('changelog_page') }}">View Changelog</a> |
   <a href="{{ url_for('help_page') }}">Help</a> |
   <a href="{{ url_for('app_settings_page') }}">App Settings</a> |
   <a href="{{ url_for('about_page') }}">About</a> |
   <a href="{{ url_for('download_database') }}">Download Database</a>
-</p>
+</nav>
 <h2>Books</h2>
 <p>Start a new book or open an existing one.</p>
+<div class="home-section book-section">
 <ul id="book_list" class="sortable" data-type="folder">
   {% for folder in all_books %}
   <li data-name="{{ folder }}">
@@ -34,4 +35,14 @@
   <button type="submit">Create Book</button>
   <a href="{{ url_for('book_wizard') }}" class="wizard-link">Book Creation Wizard</a>
 </form>
+</div>
+<div class="home-section db-section">
+  <form action="{{ url_for('export_db') }}" method="get" class="export-db-form">
+    <button type="submit">Export Database</button>
+  </form>
+  <form action="{{ url_for('import_db') }}" method="post" enctype="multipart/form-data" class="import-db-form">
+    <input type="file" name="file" accept=".calwdb" required />
+    <button type="submit">Import Database</button>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support .calwdb export and import
- add export and import buttons on the home page
- bump version to 0.8
- document the new version and feature
- clean up the home page layout

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbf49178883218d10e7551e649da0