### PR TITLE
Add .calwdb export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8 - 2025-07-22 16:56 UTC
+- Added export and import of .calwdb database files
+
 ## 0.7.5.5 - 2025-07-22 16:00 UTC
 - Home link added to the sidebar next to Settings
 - Independent scrolling for sidebar, main area, and notes sidebar

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.7.5.5
+Version 0.8
 
 CalWriter is a simple Flask application for drafting novels.
 
@@ -22,6 +22,7 @@ CalWriter is a simple Flask application for drafting novels.
 - Editor background color can be customized
 - Books can specify a color for their tab groups
 - Optional pre-edit mode for inserting icon tags with a click
+- Export and import your database as `.calwdb` files
 
 ## Running with Docker
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.7.5.5"
+VERSION = "0.8"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))
@@ -1101,6 +1101,71 @@ def download_database():
                 zf.write(path, rel)
     mem.seek(0)
     return send_file(mem, as_attachment=True, download_name='calwriter_data.zip', mimetype='application/zip')
+
+
+@app.route('/export_db')
+def export_db():
+    """Export the database as a .calwdb archive."""
+    from io import BytesIO
+    import zipfile
+
+    mem = BytesIO()
+    with zipfile.ZipFile(mem, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for root, dirs, files in os.walk(DATA_DIR):
+            for fname in files:
+                path = os.path.join(root, fname)
+                rel = os.path.relpath(path, DATA_DIR)
+                zf.write(path, rel)
+        metadata_path = os.path.join(DATA_DIR, 'metadata.json')
+        if not os.path.isfile(metadata_path):
+            zf.writestr('metadata.json', json.dumps({'version': VERSION}))
+    mem.seek(0)
+    return send_file(
+        mem,
+        as_attachment=True,
+        download_name='calwriter.calwdb',
+        mimetype='application/x-calwriter-db',
+    )
+
+
+@app.route('/import_db', methods=['POST'])
+def import_db():
+    """Import a .calwdb archive into the data directory."""
+    file = request.files.get('file')
+    if not file or not file.filename.endswith('.calwdb'):
+        flash('Invalid file')
+        return redirect(url_for('index'))
+    import zipfile
+    import tempfile
+    import shutil
+
+    try:
+        with zipfile.ZipFile(file) as zf:
+            names = zf.namelist()
+            required = {'metadata.json', 'settings.json'}
+            missing = [r for r in required if r not in names]
+            if missing:
+                flash('Archive is missing: ' + ', '.join(missing))
+                return redirect(url_for('index'))
+            for name in names:
+                if name.startswith('/') or '..' in name.split('/'):
+                    flash('Invalid path in archive')
+                    return redirect(url_for('index'))
+            temp_dir = tempfile.mkdtemp()
+            zf.extractall(temp_dir)
+    except zipfile.BadZipFile:
+        flash('File is not a valid archive')
+        return redirect(url_for('index'))
+
+    for root, dirs, files in os.walk(temp_dir):
+        rel = os.path.relpath(root, temp_dir)
+        dest = os.path.join(DATA_DIR, rel) if rel != '.' else DATA_DIR
+        os.makedirs(dest, exist_ok=True)
+        for fname in files:
+            shutil.move(os.path.join(root, fname), os.path.join(dest, fname))
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    flash('Database imported')
+    return redirect(url_for('index'))
 
 
 @app.route('/about')

--- a/static/style.css
+++ b/static/style.css
@@ -367,4 +367,19 @@ input[type="text"] {
     margin-bottom: 4px;
 }
 
+.home-section {
+    margin-bottom: 2em;
+}
+
+.db-tools {
+    border-top: 1px solid #ccc;
+    padding-top: 1em;
+}
+
+.create-book-form,
+.export-db-form,
+.import-db-form {
+    margin-top: 0.5em;
+}
+
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,28 +10,42 @@
   <a href="{{ url_for('about_page') }}">About</a> |
   <a href="{{ url_for('download_database') }}">Download Database</a>
 </p>
-<h2>Books</h2>
-<p>Start a new book or open an existing one.</p>
-<ul id="book_list" class="sortable" data-type="folder">
-  {% for folder in all_books %}
-  <li data-name="{{ folder }}">
-    {% if folder in open_books %}
-    <a href="/folder/{{ folder }}">{{ folder }}</a>
-    <form class="close-book-form" action="/folder/{{ folder }}/close" method="post" style="display:inline">
-      <button type="submit">Close</button>
-    </form>
-    {% else %}
-    <span>{{ folder }}</span>
-    <form action="/folder/{{ folder }}/open" method="post" style="display:inline">
-      <button type="submit">Open</button>
-    </form>
-    {% endif %}
-  </li>
-  {% endfor %}
-</ul>
-<form action="/folder/create" method="post" class="create-book-form">
-  <input type="text" name="name" placeholder="New book" />
-  <button type="submit">Create Book</button>
-  <a href="{{ url_for('book_wizard') }}" class="wizard-link">Book Creation Wizard</a>
-</form>
+
+<div class="home-section book-section">
+  <h2>Books</h2>
+  <p>Start a new book or open an existing one.</p>
+  <ul id="book_list" class="sortable item-list" data-type="folder">
+    {% for folder in all_books %}
+    <li data-name="{{ folder }}">
+      {% if folder in open_books %}
+      <a href="/folder/{{ folder }}">{{ folder }}</a>
+      <form class="close-book-form" action="/folder/{{ folder }}/close" method="post" style="display:inline">
+        <button type="submit">Close</button>
+      </form>
+      {% else %}
+      <span>{{ folder }}</span>
+      <form action="/folder/{{ folder }}/open" method="post" style="display:inline">
+        <button type="submit">Open</button>
+      </form>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+  <form action="/folder/create" method="post" class="create-book-form">
+    <input type="text" name="name" placeholder="New book" />
+    <button type="submit">Create Book</button>
+    <a href="{{ url_for('book_wizard') }}" class="wizard-link">Book Creation Wizard</a>
+  </form>
+</div>
+
+<div class="home-section db-tools">
+  <h2>Database Tools</h2>
+  <form action="{{ url_for('export_db') }}" method="get" class="export-db-form">
+    <button type="submit">Export Database</button>
+  </form>
+  <form action="{{ url_for('import_db') }}" method="post" enctype="multipart/form-data" class="import-db-form">
+    <input type="file" name="file" accept=".calwdb" required />
+    <button type="submit">Import Database</button>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support .calwdb export and import
- add export and import buttons on the home page
- bump version to 0.8
- document the new version and feature

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fbf49178883218d10e7551e649da0