### PR TITLE
Update import workflow and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.2 - 2025-07-22 17:20 UTC
+- Exported database files include a timestamp in the filename
+- Home page link renamed to "Download Database as a .zip"
+- Expanded Help page with a full feature overview
+- Version bump to 0.8.2
+
 ## 0.8.1 - 2025-07-22 17:10 UTC
 - Import Database button now opens file selector directly
 - Version bump to 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1 - 2025-07-22 17:10 UTC
+- Import Database button now opens file selector directly
+- Version bump to 0.8.1
+
 ## 0.8 - 2025-07-22 16:56 UTC
 - Added export and import of .calwdb database files
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.8.1
+Version 0.8.2
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/logo.png" alt="CalWriter Logo" width="25%" />
 
-Version 0.8
+Version 0.8.1
 
 CalWriter is a simple Flask application for drafting novels.
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.8.1"
+VERSION = "0.8.2"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))
@@ -1120,10 +1120,12 @@ def export_db():
         if not os.path.isfile(metadata_path):
             zf.writestr('metadata.json', json.dumps({'version': VERSION}))
     mem.seek(0)
+    timestamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+    filename = f"calwriter - {timestamp}.calwdb"
     return send_file(
         mem,
         as_attachment=True,
-        download_name='calwriter.calwdb',
+        download_name=filename,
         mimetype='application/x-calwriter-db',
     )
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 app.secret_key = 'change-this'
 
 # Application version
-VERSION = "0.8"
+VERSION = "0.8.1"
 app.jinja_env.globals['app_version'] = VERSION
 
 DATA_DIR = os.environ.get('DATA_DIR', os.path.join(os.getcwd(), 'data'))

--- a/static/style.css
+++ b/static/style.css
@@ -382,4 +382,8 @@ input[type="text"] {
     margin-top: 0.5em;
 }
 
+.import-db-form input[type=file] {
+    display: none;
+}
+
 

--- a/templates/help.html
+++ b/templates/help.html
@@ -2,9 +2,14 @@
 {% block title %}Help{% endblock %}
 {% block content %}
 <h1>CalWriter Help</h1>
-<p>The sidebar shows a collapsible tree of all your books, sub-folders and chapters. A search box lets you find text anywhere and the tree remembers which items you have expanded or collapsed.</p>
-<p>Chapters open in tabs grouped by book. Each book can have its own tab color and books, sub-folders and chapters can be closed to hide them from view.</p>
-<p>Chapters and notes save automatically as you type. The toolbar offers bold, italics, underline, lists, indent/outdent, horizontal lines, undo/redo and a find/replace tool. A pre-edit mode lets you mark text with icon tags.</p>
-<p>Use drag and drop to reorder chapters or folders. Download a single chapter or combine all chapters—including closed ones—from the book page. The stats page tracks your daily word counts.</p>
-<p>Colors and dark mode can be customized in App Settings and reset to the defaults at any time.</p>
+<p>CalWriter keeps your projects organized in books with unlimited folders and chapters. Start a new book from the home page or open an existing one to continue writing.</p>
+<ul>
+  <li><strong>Editing</strong> – Chapters open in tabs grouped by book. The rich text toolbar offers formatting, lists, undo/redo and find/replace. Notes and chapters save automatically.</li>
+  <li><strong>Navigation</strong> – The sidebar tree can be collapsed or expanded and remembers its state. Drag and drop folders or chapters to rearrange them. Right click items to rename or delete.</li>
+  <li><strong>Import/Export</strong> – Use <em>Export Database</em> to save a <code>.calwdb</code> archive or <em>Download Database as a .zip</em> for backups. <em>Import Database</em> merges an archive into your data.</li>
+  <li><strong>Book Wizard</strong> – Quickly create a book with starter folders and the first chapter.</li>
+  <li><strong>Stats and Search</strong> – Search across all books and track daily word counts on the Stats page.</li>
+  <li><strong>Customization</strong> – Choose colors for book tabs, enable dark mode and adjust editor background in App Settings. Pre-edit mode lets you insert icon tags with a click.</li>
+</ul>
+<p>Chapters can be exported to <code>.docx</code> files individually or combined from the book page. When you're done for the day, export or download your database to keep everything safe.</p>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,9 +43,9 @@
   <form action="{{ url_for('export_db') }}" method="get" class="export-db-form">
     <button type="submit">Export Database</button>
   </form>
-  <form action="{{ url_for('import_db') }}" method="post" enctype="multipart/form-data" class="import-db-form">
-    <input type="file" name="file" accept=".calwdb" required />
-    <button type="submit">Import Database</button>
+  <form action="{{ url_for('import_db') }}" method="post" enctype="multipart/form-data" class="import-db-form" id="import_db_form">
+    <input type="file" name="file" id="db_file" accept=".calwdb" style="display:none" onchange="document.getElementById('import_db_form').submit()" />
+    <button type="button" onclick="document.getElementById('db_file').click()">Import Database</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
   <a href="{{ url_for('help_page') }}">Help</a> |
   <a href="{{ url_for('app_settings_page') }}">App Settings</a> |
   <a href="{{ url_for('about_page') }}">About</a> |
-  <a href="{{ url_for('download_database') }}">Download Database</a>
+  <a href="{{ url_for('download_database') }}">Download Database as a .zip</a>
 </p>
 
 <div class="home-section book-section">


### PR DESCRIPTION
## Summary
- make the Import Database button open the file selector directly
- hide the file input with CSS
- bump CalWriter to version 0.8.1

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687fc52ccf5c8321853899b5a7298324